### PR TITLE
Validate Input

### DIFF
--- a/.tests/test_serializer.c
+++ b/.tests/test_serializer.c
@@ -6,7 +6,7 @@
 /*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/05 23:16:35 by kfujita           #+#    #+#             */
-/*   Updated: 2023/05/11 23:48:50 by kfujita          ###   ########.fr       */
+/*   Updated: 2023/05/17 09:08:12 by kfujita          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,9 +16,9 @@
 #include <unistd.h>
 
 #include "serializer.h"
+#include "validator.h"
 
 #include "../srcs/childs/_build_cmd.h"
-
 
 #define STR(S) (#S)
 
@@ -40,6 +40,19 @@ static const char	*_cmdelmtyp_to_string(t_cmd_elem_type type)
 		return (STR(CMDTYP_RED_APPEND));
 	else if (type == CMDTYP_PIPE)
 		return (STR(CMDTYP_PIPE));
+	return (NULL);
+}
+
+static const char	*_cmd_inval_typ_to_string(t_cmd_inval_typ type)
+{
+	if (type == CMD_INVAL_NO_ERR)
+		return (STR(CMD_INVAL_NO_ERR));
+	else if (type == CMD_INVAL_NOCMD)
+		return (STR(CMD_INVAL_NOCMD));
+	else if (type == CMD_INVAL_PIPE_NOPAIR)
+		return (STR(CMD_INVAL_PIPE_NOPAIR));
+	else if (type == CMD_INVAL_REDIRECT_NOARG)
+		return (STR(CMD_INVAL_REDIRECT_NOARG));
 	return (NULL);
 }
 
@@ -66,7 +79,7 @@ static void	print_elem(size_t i, const char *str, const t_cmd_elem *elem)
 	free(buf);
 }
 
-static void	print_elemarr(const char *str, const t_cmdelmarr *elemarr)
+static void	print_elemarr(const char *str, const t_cmdelmarr *elemarr, bool is_last)
 {
 	size_t		i;
 
@@ -76,18 +89,26 @@ static void	print_elemarr(const char *str, const t_cmdelmarr *elemarr)
 		print_elem(i, str, (t_cmd_elem *)vect_at(elemarr, i));
 		i++;
 	}
-	printf("\t\t(AGRC: %d)\n", _get_argc(elemarr));
+	printf("\t\t(AGRC: %d / isValid?: %s)\n",
+	_get_argc(elemarr),
+	_cmd_inval_typ_to_string(is_valid_cmd(elemarr, is_last)));
 }
 
 static void	print_cmdarr(const char *str, const t_cmdarr *cmdarr)
 {
-	size_t		i;
+	size_t			i;
+	t_cmd_i_inval	ret;
 
 	i = 0;
 	while (i < cmdarr->len)
 	{
-		printf("cmd[%zu] ~~~~~~~~~~~~~~~~~~\n", i);
-		print_elemarr(str, (t_cmdelmarr *)vect_at(cmdarr, i++));
+		ret = is_valid_input(cmdarr);
+		printf("cmd[%zu] ~~~~~~~~~~~~~~~~~~ (isValid?: %s at %zu)\n", i, _cmd_inval_typ_to_string(ret.type), ret.index);
+		print_elemarr(
+			str,
+			(t_cmdelmarr *)vect_at(cmdarr, i),
+			(i + 1) == cmdarr->len);
+		i++;
 	}
 }
 

--- a/.tests/test_serializer.c
+++ b/.tests/test_serializer.c
@@ -6,7 +6,7 @@
 /*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/05 23:16:35 by kfujita           #+#    #+#             */
-/*   Updated: 2023/05/17 09:08:12 by kfujita          ###   ########.fr       */
+/*   Updated: 2023/05/17 09:16:21 by kfujita          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,39 +20,56 @@
 
 #include "../srcs/childs/_build_cmd.h"
 
-#define STR(S) (#S)
+#define COLOR_DEFAULT "\033[0;0m"
+
+#define COLOR_RED "\033[0;31m"
+#define COLOR_GREEN "\033[0;32m"
+#define COLOR_YELLOW "\033[0;33m"
+#define COLOR_BLUE "\033[0;34m"
+#define COLOR_PURPLE "\033[0;35m"
+#define COLOR_CYAN "\033[0;36m"
+
+#define COLOR_BOLD_GRAY "\033[1;30m"
+#define COLOR_BOLD_RED "\033[1;31m"
+#define COLOR_BOLD_GREEN "\033[1;32m"
+#define COLOR_BOLD_YELLOW "\033[1;33m"
+#define COLOR_BOLD_BLUE "\033[1;34m"
+#define COLOR_BOLD_PURPLE "\033[1;35m"
+#define COLOR_BOLD_CYAN "\033[1;36m"
+
+#define STR(S) #S
 
 static const char	*_cmdelmtyp_to_string(t_cmd_elem_type type)
 {
 	if (type == CMDTYP_NORMAL)
-		return (STR(CMDTYP_NORMAL));
+		return (COLOR_BOLD_GREEN STR(CMDTYP_NORMAL) COLOR_DEFAULT);
 	else if (type == CMDTYP_VARIABLE)
-		return (STR(CMDTYP_VARIABLE));
+		return (COLOR_BOLD_PURPLE STR(CMDTYP_VARIABLE) COLOR_DEFAULT);
 	else if (type == CMDTYP_QUOTE_VAR)
-		return (STR(CMDTYP_QUOTE_VAR));
+		return (COLOR_BOLD_PURPLE STR(CMDTYP_QUOTE_VAR) COLOR_DEFAULT);
 	else if (type == CMDTYP_RED_IN)
-		return (STR(CMDTYP_RED_IN));
+		return (COLOR_BOLD_BLUE STR(CMDTYP_RED_IN) COLOR_DEFAULT);
 	else if (type == CMDTYP_RED_HEREDOC)
-		return (STR(CMDTYP_RED_HEREDOC));
+		return (COLOR_BOLD_BLUE STR(CMDTYP_RED_HEREDOC) COLOR_DEFAULT);
 	else if (type == CMDTYP_RED_OUT)
-		return (STR(CMDTYP_RED_OUT));
+		return (COLOR_BOLD_CYAN STR(CMDTYP_RED_OUT) COLOR_DEFAULT);
 	else if (type == CMDTYP_RED_APPEND)
-		return (STR(CMDTYP_RED_APPEND));
+		return (COLOR_BOLD_CYAN STR(CMDTYP_RED_APPEND) COLOR_DEFAULT);
 	else if (type == CMDTYP_PIPE)
-		return (STR(CMDTYP_PIPE));
+		return (COLOR_BOLD_YELLOW STR(CMDTYP_PIPE) COLOR_DEFAULT);
 	return (NULL);
 }
 
 static const char	*_cmd_inval_typ_to_string(t_cmd_inval_typ type)
 {
 	if (type == CMD_INVAL_NO_ERR)
-		return (STR(CMD_INVAL_NO_ERR));
+		return (COLOR_GREEN STR(CMD_INVAL_NO_ERR) COLOR_DEFAULT);
 	else if (type == CMD_INVAL_NOCMD)
-		return (STR(CMD_INVAL_NOCMD));
+		return (COLOR_BOLD_RED STR(CMD_INVAL_NOCMD) COLOR_DEFAULT);
 	else if (type == CMD_INVAL_PIPE_NOPAIR)
-		return (STR(CMD_INVAL_PIPE_NOPAIR));
+		return (COLOR_PURPLE STR(CMD_INVAL_PIPE_NOPAIR) COLOR_DEFAULT);
 	else if (type == CMD_INVAL_REDIRECT_NOARG)
-		return (STR(CMD_INVAL_REDIRECT_NOARG));
+		return (COLOR_RED STR(CMD_INVAL_REDIRECT_NOARG) COLOR_DEFAULT);
 	return (NULL);
 }
 
@@ -69,7 +86,7 @@ static void	print_elem(size_t i, const char *str, const t_cmd_elem *elem)
 	}
 	offset = elem->elem_top - str;
 	memcpy(buf, elem->elem_top, elem->len);
-	printf("\telem[%2zu]: %18s '%s'(%ld .. %zu) -> spc:%d\n",
+	printf("\telem[%2zu]:%32s '%s'(%ld .. %zu) -> spc:%d\n",
 		i,
 		_cmdelmtyp_to_string(elem->type),
 		buf,

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/05/03 18:44:27 by kfujita           #+#    #+#              #
-#    Updated: 2023/05/16 22:14:28 by kfujita          ###   ########.fr        #
+#    Updated: 2023/05/17 23:25:50 by kfujita          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -71,7 +71,7 @@ LIBFT_DIR	=	./libft
 LIBFT	=	$(LIBFT_DIR)/libft.a
 LIBFT_MAKE	=	make -C $(LIBFT_DIR)
 
-CFLAGS	=	-Wall -Wextra -Werror -MMD -MP
+override CFLAGS	+=	-Wall -Wextra -Werror -MMD -MP
 INCLUDES	=	-I $(HEADERS_DIR) -I $(LIBFT_DIR)
 
 CC		=	cc
@@ -80,6 +80,8 @@ all:	$(NAME)
 
 $(NAME):	$(LIBFT) $(OBJS)
 	$(CC) $(CFLAGS) $(INCLUDES) -o $@ $^
+debug: clean_local
+	make CFLAGS='-DDEBUG'
 
 $(OBJ_DIR)/%.o:	%.c
 	@mkdir -p $(OBJ_DIR)

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/05/03 18:44:27 by kfujita           #+#    #+#              #
-#    Updated: 2023/05/14 23:44:11 by kfujita          ###   ########.fr        #
+#    Updated: 2023/05/16 22:14:28 by kfujita          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -35,9 +35,14 @@ SRCS_SERIALIZER	= \
 	is_cetyp.c \
 	serializer.c \
 
+SRCS_VALIDATOR =\
+	is_valid_cmd.c\
+	is_valid_input.c\
+
 SRCS_NOMAIN	= \
 	$(SRCS_CHILDS)\
 	$(SRCS_SERIALIZER)\
+	$(SRCS_VALIDATOR)\
 
 HEADERS_DIR		=	./headers
 
@@ -45,6 +50,7 @@ SRCS_BASE_DIR	=	./srcs
 SRCS_MAIN_DIR	=	$(SRCS_BASE_DIR)
 SRCS_CHILDS_DIR	=	$(SRCS_BASE_DIR)/childs
 SRCS_SERIALIZER_DIR	=	$(SRCS_BASE_DIR)/serializer
+SRCS_VALIDATOR_DIR	=	$(SRCS_BASE_DIR)/validator
 
 OBJ_DIR	=	./obj
 OBJS_NOMAIN	=	$(addprefix $(OBJ_DIR)/, $(SRCS_NOMAIN:.c=.o))
@@ -55,6 +61,7 @@ VPATH	=	\
 	$(SRCS_MAIN_DIR)\
 	:$(SRCS_CHILDS_DIR)\
 	:$(SRCS_SERIALIZER_DIR)\
+	:$(SRCS_VALIDATOR_DIR)\
 
 TEST_DIR	=	.tests
 TEST_SERIALIZER	=	test_serializer

--- a/headers/validator.h
+++ b/headers/validator.h
@@ -1,0 +1,38 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   validator.h                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/05/16 21:02:37 by kfujita           #+#    #+#             */
+/*   Updated: 2023/05/16 23:24:47 by kfujita          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef VALIDATOR_H
+# define VALIDATOR_H
+
+// - bool
+# include <stdbool.h>
+
+# include "serializer.h"
+
+typedef enum e_cmd_inval_typ
+{
+	CMD_INVAL_NO_ERR,
+	CMD_INVAL_NOCMD,
+	CMD_INVAL_PIPE_NOPAIR,
+	CMD_INVAL_REDIRECT_NOARG,
+}	t_cmd_inval_typ;
+
+typedef struct s_cmd_i_inval
+{
+	size_t			index;
+	t_cmd_inval_typ	type;
+}	t_cmd_i_inval;
+
+t_cmd_i_inval	is_valid_input(const t_cmdarr *cmdarr);
+t_cmd_inval_typ	is_valid_cmd(const t_cmdelmarr *cmdelemarr, bool is_last_cmd);
+
+#endif

--- a/srcs/childs/childs_dispose.c
+++ b/srcs/childs/childs_dispose.c
@@ -6,7 +6,7 @@
 /*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/07 18:58:13 by kfujita           #+#    #+#             */
-/*   Updated: 2023/05/08 00:29:55 by kfujita          ###   ########.fr       */
+/*   Updated: 2023/05/17 23:50:32 by kfujita          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,6 +22,7 @@ void	dispose_proc_info_arr(t_ch_proc_info *info_arr)
 	if (info_arr == NULL)
 		return ;
 	i = 0;
+	dispose_t_cmdarr(info_arr->cmdarr);
 	while (info_arr->path_arr[i] != NULL)
 		free((void *)(info_arr->path_arr[i++]));
 	free(info_arr->path_arr);

--- a/srcs/childs/exec_cmd.c
+++ b/srcs/childs/exec_cmd.c
@@ -6,9 +6,12 @@
 /*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/07 19:05:51 by kfujita           #+#    #+#             */
-/*   Updated: 2023/05/18 00:22:14 by kfujita          ###   ########.fr       */
+/*   Updated: 2023/05/18 00:27:21 by kfujita          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
+
+// - errno
+#include <errno.h>
 
 // - bool
 #include <stdbool.h>
@@ -19,9 +22,14 @@
 // - exit
 #include <stdlib.h>
 
+// - strerror
+#include <string.h>
+
 // - dup2
 // - execve
 #include <unistd.h>
+
+#include "ft_printf/ft_printf.h"
 
 #include "_build_cmd.h"
 #include "_childs.h"
@@ -79,6 +87,9 @@ noreturn void	exec_command(t_ch_proc_info *info_arr, size_t index)
 	dispose_proc_info_arr(info_arr);
 	if (ret == true)
 		execve(exec_path, argv, envp);
+	if (ret == true)
+		ft_dprintf(STDERR_FILENO,
+			"minishell: %s: %s\n", argv[0], strerror(errno));
 	free_2darr((void ***)&argv);
 	exit(1);
 }

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -6,7 +6,7 @@
 /*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/03 18:45:07 by kfujita           #+#    #+#             */
-/*   Updated: 2023/05/17 22:57:22 by kfujita          ###   ########.fr       */
+/*   Updated: 2023/05/17 23:16:52 by kfujita          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,19 +24,46 @@
 
 #include "childs.h"
 #include "serializer.h"
+#include "validator.h"
 
 #define E_OPT_LESS_ARG "%s: %s: option requires an argument\n"
+#define E_INVAL_NO_CMD "minishell: no command was found at cmd[%d]\n"
+#define E_PIPE_NO_PAIR "minishell: no pipe pair was set with cmd[%d]\n"
+#define E_REDIR_NO_ARG "minishell: no redirect arg was set in cmd[%d]\n"
+#define E_VALID_UNKNOW "minishell: unknown validation error in cmd[%d]\n"
+
+static int	_validate_input(t_cmdarr *arr)
+{
+	t_cmd_i_inval	inval;
+
+	inval = is_valid_input(arr);
+	if (inval.type == CMD_INVAL_NO_ERR)
+		return (0);
+	dispose_t_cmdarr(arr);
+	if (inval.type == CMD_INVAL_NOCMD)
+		ft_dprintf(STDERR_FILENO, E_INVAL_NO_CMD, (int)(inval.index));
+	else if (inval.type == CMD_INVAL_PIPE_NOPAIR)
+		ft_dprintf(STDERR_FILENO, E_PIPE_NO_PAIR, (int)(inval.index));
+	else if (inval.type == CMD_INVAL_REDIRECT_NOARG)
+		ft_dprintf(STDERR_FILENO, E_REDIR_NO_ARG, (int)(inval.index));
+	else
+		ft_dprintf(STDERR_FILENO, E_VALID_UNKNOW, (int)(inval.index));
+	return (1);
+}
 
 // TODO: serialize後のバリデーション/エラー処理
 // TODO: init_ch_...後のエラー処理
 static int	_parse_exec(const char *str, const char *envp[])
 {
-	t_cmdarr	arr;
-	t_cprocinf	*cparr;
-	size_t		i;
-	int			cpstat;
+	t_cmdarr		arr;
+	t_cprocinf		*cparr;
+	size_t			i;
+	int				cpstat;
 
 	arr = serialize(str);
+	cpstat = _validate_input(&arr);
+	if (cpstat != 0)
+		return (cpstat);
 	cparr = init_ch_proc_info_arr(&arr, (char **)envp);
 	i = 0;
 	while (i < arr.len)

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -6,7 +6,7 @@
 /*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/03 18:45:07 by kfujita           #+#    #+#             */
-/*   Updated: 2023/05/17 23:16:52 by kfujita          ###   ########.fr       */
+/*   Updated: 2023/05/17 23:27:31 by kfujita          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,10 +14,19 @@
 #include <stdbool.h>
 
 // - exit
+// (for debug)
+// - getenv
+// - system
 #include <stdlib.h>
 
 // - STDERR_FILENO
+// (for debug)
+// - getpid
 #include <unistd.h>
+
+// (for debug)
+// - sprintf
+#include <stdio.h>
 
 #include "ft_string/ft_string.h"
 #include "ft_printf/ft_printf.h"
@@ -98,3 +107,19 @@ int	main(int argc, const char *argv[], const char *envp[])
 	_chk_do_c_opt(argc, argv, envp);
 	return (0);
 }
+
+#if DEBUG
+
+# define DEBUG_LEAKS_CMD_LEN (32)
+
+__attribute__((destructor))
+static void	destructor(void) {
+	char	cmd[DEBUG_LEAKS_CMD_LEN];
+
+	if (getenv("DEBUG") == NULL)
+		return ;
+	snprintf(cmd, DEBUG_LEAKS_CMD_LEN, "leaks %d", getpid());
+	system(cmd);
+}
+
+#endif

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -6,7 +6,7 @@
 /*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/03 18:45:07 by kfujita           #+#    #+#             */
-/*   Updated: 2023/05/16 23:08:44 by kfujita          ###   ########.fr       */
+/*   Updated: 2023/05/17 22:57:22 by kfujita          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,7 +29,7 @@
 
 // TODO: serialize後のバリデーション/エラー処理
 // TODO: init_ch_...後のエラー処理
-static void	_parse_exec(const char *str, const char *envp[])
+static int	_parse_exec(const char *str, const char *envp[])
 {
 	t_cmdarr	arr;
 	t_cprocinf	*cparr;
@@ -48,6 +48,10 @@ static void	_parse_exec(const char *str, const char *envp[])
 	while (i < arr.len)
 		waitpid(cparr[i++].pid, &cpstat, 0);
 	dispose_proc_info_arr(cparr);
+	if (WIFEXITED(cpstat))
+		return (WEXITSTATUS(cpstat));
+	else
+		return (130);
 }
 
 static void	_chk_do_c_opt(int argc, const char *argv[], const char *envp[])
@@ -59,8 +63,7 @@ static void	_chk_do_c_opt(int argc, const char *argv[], const char *envp[])
 		ft_dprintf(STDERR_FILENO, E_OPT_LESS_ARG, argv[0], argv[1]);
 		exit(2);
 	}
-	_parse_exec(argv[2], envp);
-	exit(0);
+	exit(_parse_exec(argv[2], envp));
 }
 
 int	main(int argc, const char *argv[], const char *envp[])

--- a/srcs/validator/is_valid_cmd.c
+++ b/srcs/validator/is_valid_cmd.c
@@ -1,0 +1,58 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   is_valid_cmd.c                                     :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/05/16 21:05:48 by kfujita           #+#    #+#             */
+/*   Updated: 2023/05/16 23:23:40 by kfujita          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "validator.h"
+
+#include "../childs/_build_cmd.h"
+
+static t_cmd_inval_typ	_is_valid_elem(
+	const t_cmdelmarr *cmdelemarr,
+	const t_cmd_elem *elems,
+	bool is_last_cmd)
+{
+	size_t		i;
+	size_t		tmp;
+	bool		is_cmd_shown;
+
+	i = 0;
+	is_cmd_shown = false;
+	while (i < cmdelemarr->len)
+	{
+		if (is_cetyp_terminator(elems[i].type))
+		{
+			if (is_last_cmd)
+				return (CMD_INVAL_PIPE_NOPAIR);
+			else if (i == 0)
+				return (CMD_INVAL_NOCMD);
+		}
+		tmp = _one_elem_count(cmdelemarr, i);
+		if (!is_cetyp_redirect(elems[i].type))
+			is_cmd_shown = true;
+		else if (tmp == 1)
+			return (CMD_INVAL_REDIRECT_NOARG);
+		i += tmp;
+	}
+	if (!is_cmd_shown)
+		return (CMD_INVAL_NOCMD);
+	return (CMD_INVAL_NO_ERR);
+}
+
+t_cmd_inval_typ	is_valid_cmd(const t_cmdelmarr *cmdelemarr, bool is_last_cmd)
+{
+	if (cmdelemarr == NULL || cmdelemarr->len <= 0)
+		return (CMD_INVAL_NOCMD);
+	return (_is_valid_elem(
+			cmdelemarr,
+			(t_cmd_elem *)(cmdelemarr->p),
+		is_last_cmd)
+	);
+}

--- a/srcs/validator/is_valid_input.c
+++ b/srcs/validator/is_valid_input.c
@@ -1,0 +1,30 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   is_valid_input.c                                   :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/05/16 21:32:10 by kfujita           #+#    #+#             */
+/*   Updated: 2023/05/16 21:37:47 by kfujita          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "validator.h"
+
+t_cmd_i_inval	is_valid_input(const t_cmdarr *cmdarr)
+{
+	t_cmd_i_inval	v;
+	t_cmdelmarr		*p;
+
+	v = (t_cmd_i_inval){0};
+	p = (t_cmdelmarr *)(cmdarr->p);
+	while (v.index < cmdarr->len)
+	{
+		v.type = is_valid_cmd(p + v.index, (v.index + 1) == cmdarr->len);
+		if (v.type != CMD_INVAL_NO_ERR)
+			break ;
+		v.index += 1;
+	}
+	return (v);
+}


### PR DESCRIPTION
入力のバリデーションを実装しました。

- パイプが接続されていない (パイプでコマンド入力が終端している)
- リダイレクトの引数 (ファイル名など) が指定されていない
- そもそも、コマンドが存在しない

以上の場合について、それぞれエラーメッセージを出力するようにしました。
なお、空白文字列が入力された場合は「コマンドが存在しない」ではなく「コマンドが入力されなかった」として、(bashと同様に)`exit(0)`としています。

```
> bash -c '    '; echo $?
0
```
```
> ./minishell -c '   '; echo $?
0
```
```
> ./minishell -c 'a'; echo $?
a: Command not found
1
```
```
> ./minishell -c 'a|'; echo $?
minishell: no pipe pair was set with cmd[0]
1
```
```
> ./minishell -c 'a<'; echo $?
minishell: no redirect arg was set in cmd[0]
1
```
```
> ./minishell -c '<abc'; echo $?
minishell: no command was found at cmd[0]
1
```

今回は、ついでにleaksの導入と一部リークの解消、execve実行後のエラーメッセージ出力も行っています。
(本来は別のブランチ/PRに分けるべきですが、面倒だったので…)

## leaks実行方法

`make debug` で、leaksの実行準備が整ったバイナリを生成できます。
このバイナリを生成後、環境変数等に`DEBUG=1`などと設定することにより、毎実行後にleaksが走るようになります。
もちろん、`DEBUG`をunsetしたり、そもそも`make re`等でビルドし直したりすることで、leaksは走らなくなります。
