### PR TITLE
argv[*]用のbufをmallocする際に別の長さを参照していたバグを修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/05/03 18:44:27 by kfujita           #+#    #+#              #
-#    Updated: 2023/05/17 23:25:50 by kfujita          ###   ########.fr        #
+#    Updated: 2023/05/21 16:33:10 by kfujita          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -81,7 +81,7 @@ all:	$(NAME)
 $(NAME):	$(LIBFT) $(OBJS)
 	$(CC) $(CFLAGS) $(INCLUDES) -o $@ $^
 debug: clean_local
-	make CFLAGS='-DDEBUG'
+	make CFLAGS='-DDEBUG -g -fsanitize=address'
 
 $(OBJ_DIR)/%.o:	%.c
 	@mkdir -p $(OBJ_DIR)

--- a/srcs/childs/build_cmd.c
+++ b/srcs/childs/build_cmd.c
@@ -6,7 +6,7 @@
 /*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/14 19:36:55 by kfujita           #+#    #+#             */
-/*   Updated: 2023/05/15 00:50:20 by kfujita          ###   ########.fr       */
+/*   Updated: 2023/05/21 16:31:48 by kfujita          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -58,10 +58,10 @@ static char	*_gen_argv_one_str(const t_cmd_elem *elem, size_t len,
 	while (i < len)
 		str_len += _get_elem_str_len(elem + i++, envp);
 	if (0 < len)
-		str = (char *)malloc(len + 1);
+		str = (char *)malloc(str_len + 1);
 	if (str == NULL)
 		return (NULL);
-	str[len] = 0;
+	str[str_len] = 0;
 	i = 0;
 	str_len = 0;
 	while (i < len)


### PR DESCRIPTION
文字列長を用いてmallocすべきところ、elem配列の長さを仕様して初期化していたため、場合によってsegvが起きることがあった。
この修正により、きちんとstr_len分の領域確保を行うようになった。

なお、ついでにdebug build時にAddress Sanitizerも動作させるようにした