### PR TITLE
Signal Handlers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,9 @@ SRCS_SERIALIZER	= \
 	is_cetyp.c \
 	serializer.c \
 
+SRCS_SIGNAL =\
+	init_sig_handler.c\
+
 SRCS_VALIDATOR =\
 	_validate_input.c\
 	is_valid_cmd.c\
@@ -52,6 +55,7 @@ SRCS_NOMAIN	= \
 	$(SRCS_CHILDS)\
 	$(SRCS_HEREDOC)\
 	$(SRCS_SERIALIZER)\
+	$(SRCS_SIGNAL)\
 	$(SRCS_VALIDATOR)\
 
 HEADERS_DIR		=	./headers
@@ -61,6 +65,7 @@ SRCS_MAIN_DIR	=	$(SRCS_BASE_DIR)
 SRCS_CHILDS_DIR	=	$(SRCS_BASE_DIR)/childs
 SRCS_HEREDOC_DIR	=	$(SRCS_BASE_DIR)/heredoc
 SRCS_SERIALIZER_DIR	=	$(SRCS_BASE_DIR)/serializer
+SRCS_SIGNAL_DIR	=	$(SRCS_BASE_DIR)/signal_handling
 SRCS_VALIDATOR_DIR	=	$(SRCS_BASE_DIR)/validator
 
 OBJ_DIR	=	./obj
@@ -73,6 +78,7 @@ VPATH	=	\
 	:$(SRCS_CHILDS_DIR)\
 	:$(SRCS_HEREDOC_DIR)\
 	:$(SRCS_SERIALIZER_DIR)\
+	:$(SRCS_SIGNAL_DIR)\
 	:$(SRCS_VALIDATOR_DIR)\
 
 TEST_DIR	=	.tests

--- a/headers/signal_handling.h
+++ b/headers/signal_handling.h
@@ -1,0 +1,22 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   signal_handling.h                                  :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/05/21 21:07:31 by kfujita           #+#    #+#             */
+/*   Updated: 2023/05/21 21:47:44 by kfujita          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef SIGNAL_HANDLING_H
+# define SIGNAL_HANDLING_H
+
+# include <stdbool.h>
+
+bool	get_is_interrupted(void);
+bool	init_sig_handler(void);
+void	register_rl_ev_hook_handler(void);
+
+#endif

--- a/srcs/heredoc/chk_do_heredoc.c
+++ b/srcs/heredoc/chk_do_heredoc.c
@@ -24,10 +24,10 @@
 
 #include "ft_put/ft_put.h"
 #include "ft_string/ft_string.h"
-#include "gnl/get_next_line.h"
 
 #include "../childs/_build_cmd.h"
 #include "heredoc.h"
+#include "signal_handling.h"
 
 #define PROMPT_STR "> "
 
@@ -61,13 +61,14 @@ static bool	_read_write(const char *term, int fd)
 	while (true)
 	{
 		gnl_result = readline(PROMPT_STR);
-		if (gnl_result == NULL || is_same_line(term, gnl_result))
+		if (gnl_result == NULL || get_is_interrupted()
+			|| is_same_line(term, gnl_result))
 			break ;
 		ft_putendl_fd(gnl_result, fd);
 		free(gnl_result);
 	}
 	free(gnl_result);
-	return (true);
+	return (!get_is_interrupted());
 }
 
 static bool	_do_heredoc(const t_cmdelmarr *elems, size_t *i, int fd)

--- a/srcs/heredoc/chk_do_heredoc.c
+++ b/srcs/heredoc/chk_do_heredoc.c
@@ -16,6 +16,9 @@
 // - free
 #include <stdlib.h>
 
+// - readline etc.
+#include <readline/readline.h>
+
 // - STDIN_FILENO
 #include <unistd.h>
 
@@ -52,28 +55,21 @@ static bool	is_same_line(const char *a, const char *b)
 
 static bool	_read_write(const char *term, int fd)
 {
-	t_gnl_state	state;
-	char		*gnl_result;
+	char	*gnl_result;
 
-	state = gen_gnl_state(STDIN_FILENO, 256);
-	if (state.buf == NULL)
-		return (false);
 	gnl_result = NULL;
 	while (true)
 	{
-		write(STDOUT_FILENO, PROMPT_STR, sizeof(PROMPT_STR) - 1);
-		gnl_result = get_next_line(&state);
+		gnl_result = readline(PROMPT_STR);
 		if (gnl_result == NULL || is_same_line(term, gnl_result))
 			break ;
-		ft_putstr_fd(gnl_result, fd);
+		ft_putendl_fd(gnl_result, fd);
 		free(gnl_result);
 	}
 	free(gnl_result);
-	dispose_gnl_state(&state);
 	return (true);
 }
 
-// TODO: readlineを使って書き直す
 static bool	_do_heredoc(const t_cmdelmarr *elems, size_t *i, int fd)
 {
 	char	*term;

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -71,7 +71,7 @@ int	main(int argc, const char *argv[], char *const envp[])
 			ret = 1;
 		else if (line == NULL)
 			return (ret);
-		else
+		else if (*line != '\0')
 		{
 			ret = _parse_exec(line, envp);
 			if (*line != '\0')

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -36,6 +36,7 @@
 #include "ft_printf/ft_printf.h"
 
 #include "childs.h"
+#include "signal_handling.h"
 
 #define PROMPT_STR "minishell> "
 
@@ -59,15 +60,23 @@ int	main(int argc, const char *argv[], char *const envp[])
 	int		ret;
 
 	_chk_do_c_opt(argc, argv, envp);
+	if (!init_sig_handler())
+		return (1);
 	ret = 0;
 	while (true)
 	{
+		register_rl_ev_hook_handler();
 		line = readline(PROMPT_STR);
-		if (line == NULL)
+		if (get_is_interrupted())
+			ret = 1;
+		else if (line == NULL)
 			return (ret);
-		ret = _parse_exec(line, envp);
-		if (*line != '\0')
-			add_history(line);
+		else
+		{
+			ret = _parse_exec(line, envp);
+			if (*line != '\0')
+				add_history(line);
+		}
 		free(line);
 		rl_on_new_line();
 	}

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -73,9 +73,8 @@ int	main(int argc, const char *argv[], char *const envp[])
 			return (ret);
 		else if (*line != '\0')
 		{
+			add_history(line);
 			ret = _parse_exec(line, envp);
-			if (*line != '\0')
-				add_history(line);
 		}
 		free(line);
 		rl_on_new_line();

--- a/srcs/signal_handling/init_sig_handler.c
+++ b/srcs/signal_handling/init_sig_handler.c
@@ -6,7 +6,7 @@
 /*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/21 21:02:15 by kfujita           #+#    #+#             */
-/*   Updated: 2023/05/21 23:04:49 by kfujita          ###   ########.fr       */
+/*   Updated: 2023/05/21 23:18:56 by kfujita          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,12 +34,9 @@ inline bool	get_is_interrupted(void)
 	return (g_is_interrupted == true);
 }
 
-// SIGQUIT: Ctrl-Backslash
 // SIGINT: Ctrl-C
 static void	_sig_handler(int sig_no)
 {
-	if (sig_no == SIGQUIT)
-		return ;
 	if (sig_no != SIGINT)
 		return ;
 	g_is_interrupted = true;
@@ -61,6 +58,7 @@ static int	_rl_ev_hook_handler(void)
 bool	init_sig_handler(void)
 {
 	struct sigaction	action;
+	struct sigaction	action_sigquit;
 
 	action.sa_handler = _sig_handler;
 	action.sa_flags = 0;
@@ -69,8 +67,10 @@ bool	init_sig_handler(void)
 		perror("minishell: signal handler init");
 		return (false);
 	}
+	action_sigquit = action;
+	action_sigquit.sa_handler = SIG_IGN;
 	if (sigaction(SIGINT, &action, NULL) != 0
-		|| sigaction(SIGQUIT, &action, NULL) != 0)
+		|| sigaction(SIGQUIT, &action_sigquit, NULL) != 0)
 	{
 		perror("minishell: register signal handler");
 		return (false);

--- a/srcs/signal_handling/init_sig_handler.c
+++ b/srcs/signal_handling/init_sig_handler.c
@@ -6,7 +6,7 @@
 /*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/21 21:02:15 by kfujita           #+#    #+#             */
-/*   Updated: 2023/05/21 22:04:40 by kfujita          ###   ########.fr       */
+/*   Updated: 2023/05/21 22:28:37 by kfujita          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,7 +27,7 @@
 
 #include "signal_handling.h"
 
-static bool	g_is_interrupted = false;
+static volatile bool	g_is_interrupted = false;
 
 inline bool	get_is_interrupted(void)
 {

--- a/srcs/signal_handling/init_sig_handler.c
+++ b/srcs/signal_handling/init_sig_handler.c
@@ -6,7 +6,7 @@
 /*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/21 21:02:15 by kfujita           #+#    #+#             */
-/*   Updated: 2023/05/21 22:28:37 by kfujita          ###   ########.fr       */
+/*   Updated: 2023/05/21 23:04:49 by kfujita          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,11 +27,11 @@
 
 #include "signal_handling.h"
 
-static volatile bool	g_is_interrupted = false;
+static volatile sig_atomic_t	g_is_interrupted = false;
 
 inline bool	get_is_interrupted(void)
 {
-	return (g_is_interrupted);
+	return (g_is_interrupted == true);
 }
 
 // SIGQUIT: Ctrl-Backslash

--- a/srcs/signal_handling/init_sig_handler.c
+++ b/srcs/signal_handling/init_sig_handler.c
@@ -1,0 +1,89 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   init_sig_handler.c                                 :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/05/21 21:02:15 by kfujita           #+#    #+#             */
+/*   Updated: 2023/05/21 22:04:40 by kfujita          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+// - sigaction
+// - sigemptyset
+#include <signal.h>
+
+// - perror
+#include <stdio.h>
+
+// - write
+// - STDOUT_FILENO
+#include <unistd.h>
+
+// - rl_event_hook
+// - rl_done
+#include <readline/readline.h>
+
+#include "signal_handling.h"
+
+static bool	g_is_interrupted = false;
+
+inline bool	get_is_interrupted(void)
+{
+	return (g_is_interrupted);
+}
+
+// SIGQUIT: Ctrl-Backslash
+// SIGINT: Ctrl-C
+static void	_sig_handler(int sig_no)
+{
+	if (sig_no == SIGQUIT)
+		return ;
+	if (sig_no != SIGINT)
+		return ;
+	g_is_interrupted = true;
+}
+
+// ref: http://ogawa.s18.xrea.com/tdiary/20080319p02.html
+static int	_rl_ev_hook_handler(void)
+{
+	if (!g_is_interrupted)
+		return (0);
+	rl_event_hook = NULL;
+	rl_done = true;
+	return (0);
+}
+
+// rl_catch_signals ref:
+//   https://docs.rtems.org/releases/4.5.1-pre3/toolsdoc/gdb-5.0-docs/readline/
+//     readline00030.html
+bool	init_sig_handler(void)
+{
+	struct sigaction	action;
+
+	action.sa_handler = _sig_handler;
+	action.sa_flags = 0;
+	if (sigemptyset(&action.sa_mask) != 0)
+	{
+		perror("minishell: signal handler init");
+		return (false);
+	}
+	if (sigaction(SIGINT, &action, NULL) != 0
+		|| sigaction(SIGQUIT, &action, NULL) != 0)
+	{
+		perror("minishell: register signal handler");
+		return (false);
+	}
+	rl_catch_signals = 0;
+	g_is_interrupted = false;
+	return (true);
+}
+
+void	register_rl_ev_hook_handler(void)
+{
+	if (g_is_interrupted)
+		write(STDOUT_FILENO, "\n", 1);
+	g_is_interrupted = false;
+	rl_event_hook = _rl_ev_hook_handler;
+}


### PR DESCRIPTION
SIGINT (Ctrl+C)、SIGQUIT (Ctrl+\)に対するシグナルハンドラを作成し、それに応じたreadlineの設定も行った。

## SIGINT受信時

現在の行に入力されているデータは表示させたまま、次の行にプロンプトを表示させる。
なお、入力されている内容はバッファに残さない。

```
$ ls^C
$ (Enter)
$ 
```

つまり、上記のような入力で、`ls`コマンドは実行されない。

なお、exit statusは1である。

## SIGQUIT受信時

シグナルを握り潰す

## 残りタスク

- [x] heredoc中のSIGINT処理
(heredoc中にSIGINTが来た場合も、exit statusは1になる)