### PR TITLE
Change Makefile Style

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,8 +78,9 @@ LIB_LINK	:=	-lreadline
 # os switch ref: https://qiita.com/y-vectorfield/items/5e117e090ed38422de6b
 OS_TYPE	:= $(shell uname -s)
 ifeq ($(OS_TYPE),Darwin)
-	INCLUDES += -I$(shell brew --prefix readline)/include
-	LIB_LINK += -L$(shell brew --prefix readline)/lib
+	GNU_READLINE_DIR := $(shell brew --prefix readline)
+	INCLUDES += -I$(GNU_READLINE_DIR)/include
+	LIB_LINK += -L$(GNU_READLINE_DIR)/lib
 endif
 
 CC		:=	cc

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/05/03 18:44:27 by kfujita           #+#    #+#              #
-#    Updated: 2023/05/22 23:00:11 by kfujita          ###   ########.fr        #
+#    Updated: 2023/05/23 23:44:25 by kfujita          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -49,31 +49,19 @@ SRCS_VALIDATOR =\
 	is_valid_input.c\
 
 SRCS_NOMAIN	= \
-	$(SRCS_CHILDS)\
-	$(SRCS_HEREDOC)\
-	$(SRCS_SERIALIZER)\
-	$(SRCS_VALIDATOR)\
+	$(addprefix childs/, $(SRCS_CHILDS))\
+	$(addprefix heredoc/, $(SRCS_HEREDOC))\
+	$(addprefix serializer/, $(SRCS_SERIALIZER))\
+	$(addprefix validator/, $(SRCS_VALIDATOR))\
 
 HEADERS_DIR		=	./headers
 
 SRCS_BASE_DIR	=	./srcs
-SRCS_MAIN_DIR	=	$(SRCS_BASE_DIR)
-SRCS_CHILDS_DIR	=	$(SRCS_BASE_DIR)/childs
-SRCS_HEREDOC_DIR	=	$(SRCS_BASE_DIR)/heredoc
-SRCS_SERIALIZER_DIR	=	$(SRCS_BASE_DIR)/serializer
-SRCS_VALIDATOR_DIR	=	$(SRCS_BASE_DIR)/validator
 
 OBJ_DIR	=	./obj
 OBJS_NOMAIN	=	$(addprefix $(OBJ_DIR)/, $(SRCS_NOMAIN:.c=.o))
 OBJS	=	$(OBJS_NOMAIN) $(addprefix $(OBJ_DIR)/, $(SRCS_MAIN:.c=.o))
 DEPS	=	$(addprefix $(OBJ_DIR)/, $(OBJS:.o=.d))
-
-VPATH	=	\
-	$(SRCS_MAIN_DIR)\
-	:$(SRCS_CHILDS_DIR)\
-	:$(SRCS_HEREDOC_DIR)\
-	:$(SRCS_SERIALIZER_DIR)\
-	:$(SRCS_VALIDATOR_DIR)\
 
 TEST_DIR	=	.tests
 TEST_SERIALIZER	=	test_serializer
@@ -103,8 +91,8 @@ $(NAME):	$(LIBFT) $(OBJS)
 debug: clean_local
 	make CFLAGS='-DDEBUG -g -fsanitize=address'
 
-$(OBJ_DIR)/%.o:	%.c
-	@mkdir -p $(OBJ_DIR)
+$(OBJ_DIR)/%.o:	$(SRCS_BASE_DIR)/%.c
+	@test -d '$(dir $@)' || mkdir -p '$(dir $@)'
 	$(CC) $(CFLAGS) $(INCLUDES) -c -o $@ $<
 
 $(LIBFT):

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/05/03 18:44:27 by kfujita           #+#    #+#              #
-#    Updated: 2023/05/23 23:51:13 by kfujita          ###   ########.fr        #
+#    Updated: 2023/05/28 19:49:16 by kfujita          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -90,7 +90,7 @@ all:	$(NAME)
 $(NAME):	$(OBJS) $(LIBFT)
 	$(CC) $(CFLAGS) $(INCLUDES) -o $@ $^ $(LIB_LINK)
 debug: clean_local_obj
-	make CFLAGS='-DDEBUG -g -fsanitize=address'
+	make CFLAGS='-DDEBUG -g'
 faddr: clean_local_obj
 	make CFLAGS='-g -fsanitize=address'
 fleak: clean_local_obj

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/05/03 18:44:27 by kfujita           #+#    #+#              #
-#    Updated: 2023/05/23 23:47:47 by kfujita          ###   ########.fr        #
+#    Updated: 2023/05/23 23:51:13 by kfujita          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -87,8 +87,8 @@ CC		:=	cc
 
 all:	$(NAME)
 
-$(NAME):	$(LIBFT) $(OBJS)
-	$(CC) $(CFLAGS) $(INCLUDES) $(LIB_LINK) -o $@ $^
+$(NAME):	$(OBJS) $(LIBFT)
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ $^ $(LIB_LINK)
 debug: clean_local
 	make CFLAGS='-DDEBUG -g -fsanitize=address'
 

--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ fclean:	fclean_local
 re:	fclean all
 
 norm:
-	norminette $(HEADERS_DIR) $(SRCS_MAIN_DIR)
+	norminette $(HEADERS_DIR) $(SRCS_BASE_DIR)
 
 -include $(DEPS)
 

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ all:	$(NAME)
 
 $(NAME):	$(OBJS) $(LIBFT)
 	$(CC) $(CFLAGS) $(INCLUDES) -o $@ $^ $(LIB_LINK)
-debug: clean_local
+debug: clean_local_obj
 	make CFLAGS='-DDEBUG -g -fsanitize=address'
 
 $(OBJ_DIR)/%.o:	$(SRCS_BASE_DIR)/%.c
@@ -100,6 +100,9 @@ $(LIBFT):
 	$(LIBFT_MAKE)
 
 bonus:	$(NAME)
+
+clean_local_obj:
+	rm -f $(OBJS)
 
 clean_local:
 	rm -rf $(OBJ_DIR)

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,10 @@ $(NAME):	$(OBJS) $(LIBFT)
 	$(CC) $(CFLAGS) $(INCLUDES) -o $@ $^ $(LIB_LINK)
 debug: clean_local_obj
 	make CFLAGS='-DDEBUG -g -fsanitize=address'
+faddr: clean_local_obj
+	make CFLAGS='-g -fsanitize=address'
+fleak: clean_local_obj
+	make CFLAGS='-g -fsanitize=leak'
 
 $(OBJ_DIR)/%.o:	$(SRCS_BASE_DIR)/%.c
 	@test -d '$(dir $@)' || mkdir -p '$(dir $@)'

--- a/Makefile
+++ b/Makefile
@@ -6,16 +6,16 @@
 #    By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/05/03 18:44:27 by kfujita           #+#    #+#              #
-#    Updated: 2023/05/23 23:44:25 by kfujita          ###   ########.fr        #
+#    Updated: 2023/05/23 23:47:47 by kfujita          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
-NAME	=	minishell
+NAME	:=	minishell
 
-SRCS_MAIN	= \
+SRCS_MAIN	:= \
 	main.c \
 
-SRCS_CHILDS	=\
+SRCS_CHILDS	:=\
 	_exec_ch_proc_info_arr.c\
 	_get_argc.c\
 	_one_elem_count.c\
@@ -29,12 +29,12 @@ SRCS_CHILDS	=\
 	filectrl_tools.c\
 	init_ch_proc_info_arr.c\
 
-SRCS_HEREDOC =\
+SRCS_HEREDOC :=\
 	chk_do_heredoc.c\
 	create_tmpfile.c\
 	rm_tmpfile.c\
 
-SRCS_SERIALIZER	= \
+SRCS_SERIALIZER	:= \
 	_serializer_dquote.c \
 	_serializer_pipe_red.c \
 	_serializer_squote.c \
@@ -43,37 +43,37 @@ SRCS_SERIALIZER	= \
 	is_cetyp.c \
 	serializer.c \
 
-SRCS_VALIDATOR =\
+SRCS_VALIDATOR :=\
 	_validate_input.c\
 	is_valid_cmd.c\
 	is_valid_input.c\
 
-SRCS_NOMAIN	= \
+SRCS_NOMAIN	:= \
 	$(addprefix childs/, $(SRCS_CHILDS))\
 	$(addprefix heredoc/, $(SRCS_HEREDOC))\
 	$(addprefix serializer/, $(SRCS_SERIALIZER))\
 	$(addprefix validator/, $(SRCS_VALIDATOR))\
 
-HEADERS_DIR		=	./headers
+HEADERS_DIR		:=	./headers
 
-SRCS_BASE_DIR	=	./srcs
+SRCS_BASE_DIR	:=	./srcs
 
-OBJ_DIR	=	./obj
-OBJS_NOMAIN	=	$(addprefix $(OBJ_DIR)/, $(SRCS_NOMAIN:.c=.o))
-OBJS	=	$(OBJS_NOMAIN) $(addprefix $(OBJ_DIR)/, $(SRCS_MAIN:.c=.o))
-DEPS	=	$(addprefix $(OBJ_DIR)/, $(OBJS:.o=.d))
+OBJ_DIR	:=	./obj
+OBJS_NOMAIN	:=	$(addprefix $(OBJ_DIR)/, $(SRCS_NOMAIN:.c=.o))
+OBJS	:=	$(OBJS_NOMAIN) $(addprefix $(OBJ_DIR)/, $(SRCS_MAIN:.c=.o))
+DEPS	:=	$(addprefix $(OBJ_DIR)/, $(OBJS:.o=.d))
 
-TEST_DIR	=	.tests
-TEST_SERIALIZER	=	test_serializer
-TEST_BUILD_CMD	=	test_build_cmd
+TEST_DIR	:=	.tests
+TEST_SERIALIZER	:=	test_serializer
+TEST_BUILD_CMD	:=	test_build_cmd
 
-LIBFT_DIR	=	./libft
-LIBFT	=	$(LIBFT_DIR)/libft.a
-LIBFT_MAKE	=	make -C $(LIBFT_DIR)
+LIBFT_DIR	:=	./libft
+LIBFT	:=	$(LIBFT_DIR)/libft.a
+LIBFT_MAKE	:=	make -C $(LIBFT_DIR)
 
 override CFLAGS	+=	-Wall -Wextra -Werror -MMD -MP
-INCLUDES	=	-I $(HEADERS_DIR) -I $(LIBFT_DIR)
-LIB_LINK	=	-lreadline
+INCLUDES	:=	-I $(HEADERS_DIR) -I $(LIBFT_DIR)
+LIB_LINK	:=	-lreadline
 
 # os switch ref: https://qiita.com/y-vectorfield/items/5e117e090ed38422de6b
 OS_TYPE	:= $(shell uname -s)
@@ -82,7 +82,7 @@ ifeq ($(OS_TYPE),Darwin)
 	LIB_LINK += -L$(shell brew --prefix readline)/lib
 endif
 
-CC		=	cc
+CC		:=	cc
 
 all:	$(NAME)
 


### PR DESCRIPTION
`VPATH`にディレクトリを書き連ねるのが面倒になったのと、ディレクトリ間でファイル名の競合を気にしなくちゃいけないという点に不便さを感じてきたので、`VPATH`を使わない形に書き直しました。

これからは、ソースファイルのファイル名リストを一つの変数に入れて、それに`addprefix`したものを`SRCS_NOMAIN`に追加する形になります。

https://github.com/TR-42/minishell/blob/487f31eb570d7e40e2aa6a48c83f67dd85d3f603/Makefile#L45-L56

---

ついでに、make実行速度の高速化(効果不明)と、Linux環境でもビルドできるようにしました。