### PR TITLE
DQUOTE_VARの直後にスペースがある場合にそれが無視されるバグを修正

### DIFF
--- a/srcs/serializer/serializer.c
+++ b/srcs/serializer/serializer.c
@@ -6,7 +6,7 @@
 /*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/04 20:01:01 by kfujita           #+#    #+#             */
-/*   Updated: 2023/05/07 01:28:43 by kfujita          ###   ########.fr       */
+/*   Updated: 2023/05/26 23:11:39 by kfujita          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -52,7 +52,7 @@ static bool	_take_elems(t_cmdelmarr *elmarr, const char **input)
 	mode = M_NORMAL;
 	while (**input != '\0')
 	{
-		if (ft_isspace(**input))
+		if (mode == M_NORMAL && ft_isspace(**input))
 			*input += 1;
 		else
 		{


### PR DESCRIPTION
`"$a "`など、変数の直後にスペースが入っていた場合に、スペースが無視されてしまっていました。
その結果、内部処理との兼ね合いもあり、過剰な読み取りが行われる場合もありました。

この変更により、「スペースでのスキップは、通常のコマンドモード (`M_NORMAL`) 時のみ」になりました。
(というか、NORMAL以外でskipしてた今までが実装ミス)