### PR TITLE
heredocでの変数指定を無効化

### DIFF
--- a/.tests/test_serializer.sh
+++ b/.tests/test_serializer.sh
@@ -109,3 +109,13 @@ $1\
 	'a | b'\
 	'a<|$b'\
 	'abc $a|$b'\
+
+echo "Combination Tests"
+
+$1\
+	'abc"$def"'\
+	"abc'\$DEF'"\
+	'abc">$def"'\
+	"abc'<\$DEF'"\
+	'abc>"$def"'\
+	"abc<'\$DEF'"\

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ SRCS_CHILDS	=\
 SRCS_HEREDOC =\
 	chk_do_heredoc.c\
 	create_tmpfile.c\
+	ignore_var_in_delimiter.c\
 	rm_tmpfile.c\
 
 SRCS_SERIALIZER	= \

--- a/headers/heredoc.h
+++ b/headers/heredoc.h
@@ -24,4 +24,6 @@ bool	chk_do_heredoc(t_cmdarr *cmdarr, char *const *envp);
 
 int		rm_tmpfile(t_cmdarr *cmdarr);
 
+void	ignore_var_in_delimiter(t_cmdelmarr *elemarr);
+
 #endif

--- a/headers/serializer.h
+++ b/headers/serializer.h
@@ -53,6 +53,7 @@ t_cmdarr	serialize(const char *input);
 int			dispose_t_cmdarr(t_cmdarr *cmd);
 
 bool		is_cetyp_redirect(t_cmd_elem_type t);
+bool		is_cetyp_var(t_cmd_elem_type t);
 bool		is_cetyp_var_or_normal(t_cmd_elem_type t);
 bool		is_cetyp_terminator(t_cmd_elem_type t);
 

--- a/srcs/heredoc/chk_do_heredoc.c
+++ b/srcs/heredoc/chk_do_heredoc.c
@@ -121,6 +121,7 @@ bool	chk_do_heredoc(t_cmdarr *cmdarr, char *const *envp)
 	cmds = (t_cmdelmarr *)(cmdarr->p);
 	while (i_cmd < cmdarr->len)
 	{
+		ignore_var_in_delimiter(cmds + i_cmd);
 		if (!_chk_do_heredoc_elemarr(cmds + i_cmd, envp))
 			return (false);
 		i_cmd += 1;

--- a/srcs/heredoc/ignore_var_in_delimiter.c
+++ b/srcs/heredoc/ignore_var_in_delimiter.c
@@ -1,0 +1,44 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ignore_var_in_delimiter.c                          :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/05/28 15:39:09 by kfujita           #+#    #+#             */
+/*   Updated: 2023/05/28 16:05:35 by kfujita          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "serializer.h"
+#include "childs.h"
+#include "../childs/_build_cmd.h"
+
+void	ignore_var_in_delimiter(t_cmdelmarr *elemarr)
+{
+	size_t		i;
+	size_t		i_last;
+	t_cmd_elem	*elems;
+
+	i = 0;
+	elems = (t_cmd_elem *)(elemarr->p);
+	while (i < elemarr->len)
+	{
+		if (elems[i].type == CMDTYP_RED_HEREDOC
+			|| elems[i].type == CMDTYP_RED_HEREDOC_SAVED)
+		{
+			i_last = i + _one_elem_count(elemarr, i + 1);
+			while (++i <= i_last)
+			{
+				if (is_cetyp_var(elems[i].type))
+				{
+					elems[i].elem_top -= 1;
+					elems[i].len += 1;
+				}
+				elems[i].type = CMDTYP_NORMAL;
+			}
+		}
+		else
+			i++;
+	}
+}

--- a/srcs/serializer/_serializer_dquote.c
+++ b/srcs/serializer/_serializer_dquote.c
@@ -6,7 +6,7 @@
 /*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/05 21:00:06 by kfujita           #+#    #+#             */
-/*   Updated: 2023/05/06 16:46:36 by kfujita          ###   ########.fr       */
+/*   Updated: 2023/05/28 16:39:16 by kfujita          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,6 +21,11 @@ static bool	_when_mode_is_not_dquote(const char **input, t_pars_mde *mode,
 		return (false);
 	*mode = M_DQUOTE;
 	*input += 1;
+	if (0 < v->len)
+	{
+		v->nospace = true;
+		return (true);
+	}
 	v->elem_top = *input;
 	return (false);
 }

--- a/srcs/serializer/_serializer_squote.c
+++ b/srcs/serializer/_serializer_squote.c
@@ -6,7 +6,7 @@
 /*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/05 21:00:06 by kfujita           #+#    #+#             */
-/*   Updated: 2023/05/05 23:12:59 by kfujita          ###   ########.fr       */
+/*   Updated: 2023/05/28 16:39:45 by kfujita          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,6 +23,11 @@ bool	_serializer_squote(const char **input, t_pars_mde *mode, t_cmd_elem *v)
 			return (false);
 		*mode = M_SQUOTE;
 		*input += 1;
+		if (0 < v->len)
+		{
+			v->nospace = true;
+			return (true);
+		}
 		v->elem_top = *input;
 		return (false);
 	}

--- a/srcs/serializer/is_cetyp.c
+++ b/srcs/serializer/is_cetyp.c
@@ -21,11 +21,16 @@ bool	is_cetyp_redirect(t_cmd_elem_type t)
 		|| t == CMDTYP_RED_OUT);
 }
 
+bool	is_cetyp_var(t_cmd_elem_type t)
+{
+	return (t == CMDTYP_QUOTE_VAR
+		|| t == CMDTYP_VARIABLE);
+}
+
 bool	is_cetyp_var_or_normal(t_cmd_elem_type t)
 {
 	return (t == CMDTYP_NORMAL
-		|| t == CMDTYP_QUOTE_VAR
-		|| t == CMDTYP_VARIABLE);
+		|| is_cetyp_var(t));
 }
 
 bool	is_cetyp_terminator(t_cmd_elem_type t)


### PR DESCRIPTION
heredocでは変数を使用できないため、予め`CMDTYP_NORMAL`に変更するようにした