### PR TITLE
Redirectのファイル名に不正な変数が指定された際にエラーを吐くようにした

### DIFF
--- a/.tests/test_build_cmd.c
+++ b/.tests/test_build_cmd.c
@@ -17,12 +17,15 @@
 #include "_build_cmd.h"
 
 #include "serializer.h"
+#include "validator.h"
 
 static void	_free_argv(char **argv)
 {
 	size_t	i;
 
 	i = 0;
+	if (argv == NULL)
+		return ;
 	while (argv[i] != NULL)
 		free(argv[i++]);
 	free(argv);

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ SRCS_VALIDATOR =\
 	_validate_input.c\
 	is_valid_cmd.c\
 	is_valid_input.c\
+	validate_red_fname.c\
 
 SRCS_NOMAIN	:= \
 	$(addprefix build_cmd/, $(SRCS_BUILD_CMD))\

--- a/headers/validator.h
+++ b/headers/validator.h
@@ -40,4 +40,7 @@ t_cmd_i_inval	is_valid_input(const t_cmdarr *cmdarr)
 t_cmd_inval_typ	is_valid_cmd(const t_cmdelmarr *cmdelemarr, bool is_last_cmd)
 				__attribute__((nonnull));
 
+bool			validate_red_fname(const t_cmdelmarr *elemarr)
+				__attribute__((nonnull(1)));
+
 #endif

--- a/srcs/build_cmd/build_cmd.c
+++ b/srcs/build_cmd/build_cmd.c
@@ -16,6 +16,7 @@
 #include "ft_string/ft_string.h"
 
 #include "error_utils.h"
+#include "validator.h"
 #include "_build_cmd.h"
 
 // !! NO_ERROR
@@ -106,6 +107,8 @@ char	*_get_argv_one(const t_cmdelmarr *elemarr, size_t *i_start)
 //   - リダイレクトの引数は正常に設定されている
 // !! ERR_PRINTED
 // -> <inherit> set_var_values
+// -> <inherit> validate_red_fname (validation error)
+// -> <inherit> elems_make_flat
 // -> (root) for _get_argc
 // -> (root) for malloc
 // -> <inherit> _get_argv_one
@@ -117,7 +120,8 @@ char	**build_cmd(t_cmdelmarr *elemarr, char *const *envp)
 	int			i_argv;
 	size_t		i_elemarr;
 
-	if (!set_var_values(elemarr, envp) || !elems_make_flat(elemarr))
+	if (!set_var_values(elemarr, envp) || !validate_red_fname(elemarr)
+		|| !elems_make_flat(elemarr))
 		return (NULL);
 	argc = _get_argc(elemarr);
 	if (argc <= 0)
@@ -127,10 +131,7 @@ char	**build_cmd(t_cmdelmarr *elemarr, char *const *envp)
 	}
 	argv = (char **)malloc(sizeof(char **) * ((size_t)argc + 1));
 	if (argv == NULL)
-	{
-		strerr_ret_false("build_cmd()/malloc");
-		return (NULL);
-	}
+		return ((void *)(strerr_ret_false("build_cmd()/malloc") * 0UL));
 	argv[argc] = NULL;
 	i_argv = 0;
 	i_elemarr = 0;

--- a/srcs/validator/validate_red_fname.c
+++ b/srcs/validator/validate_red_fname.c
@@ -61,7 +61,7 @@ static bool	_print_ref_fname_err(const t_cmd_elem *elems, size_t elems_len)
 	top = elems[i].elem_top - 1;
 	if (elems[i].type == CMDTYP_QUOTE_VAR)
 		top -= 1;
-	else if (*top != '\'' && *top != '\"')
+	else if (*top != '\'' && *top != '\"' && *top != '$')
 		top += 1;
 	str_len = (elems[elems_len - 1].elem_top + elems[elems_len - 1].len - top);
 	if (elems[elems_len - 1].type != CMDTYP_NORMAL

--- a/srcs/validator/validate_red_fname.c
+++ b/srcs/validator/validate_red_fname.c
@@ -36,7 +36,8 @@ static bool	_validate_red_fname(const t_cmd_elem *elems, size_t *i,
 			is_val_set = true;
 		else if (1 < elems[*i + j].p_mlc_len)
 			return (false);
-		else if (elems[*i + j].p_malloced != NULL)
+		else if (elems[*i + j].p_malloced != NULL
+			&& elems[*i + j].p_malloced[0] != '\0')
 			is_val_set = true;
 		j++;
 	}

--- a/srcs/validator/validate_red_fname.c
+++ b/srcs/validator/validate_red_fname.c
@@ -1,0 +1,100 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   validate_red_fname.c                               :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/05/28 21:39:43 by kfujita           #+#    #+#             */
+/*   Updated: 2023/05/29 21:35:58 by kfujita          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+// - malloc
+// - free
+#include <stdlib.h>
+
+#include "ft_mem/ft_mem.h"
+
+#include "error_utils.h"
+#include "validator.h"
+#include "_build_cmd.h"
+
+// !! NO_ERROR
+__attribute__((nonnull))
+static bool	_validate_red_fname(const t_cmd_elem *elems, size_t *i,
+	size_t oneelem_len)
+{
+	size_t		j;
+	bool		is_val_set;
+
+	is_val_set = false;
+	j = 0;
+	while (j < oneelem_len)
+	{
+		if (elems[*i + j].type != CMDTYP_VARIABLE)
+			is_val_set = true;
+		else if (1 < elems[*i + j].p_mlc_len)
+			return (false);
+		else if (elems[*i + j].p_malloced != NULL)
+			is_val_set = true;
+		j++;
+	}
+	if (!is_val_set)
+		return (false);
+	*i += oneelem_len - 1;
+	return (true);
+}
+
+// !! ERR_PRINTED
+// -> (root) for malloc failed
+__attribute__((nonnull))
+static bool	_print_ref_fname_err(const t_cmd_elem *elems, size_t elems_len)
+{
+	size_t		str_len;
+	const char	*top;
+	size_t		i;
+	char		*buf;
+
+	i = 0;
+	top = elems[i].elem_top - 1;
+	if (elems[i].type == CMDTYP_QUOTE_VAR)
+		top -= 1;
+	else if (*top != '\'' && *top != '\"')
+		top += 1;
+	str_len = (elems[elems_len - 1].elem_top + elems[elems_len - 1].len - top);
+	if (elems[elems_len - 1].type != CMDTYP_NORMAL
+		&& (top[str_len] == '\'' || top[str_len] == '\"'))
+		str_len += 1;
+	buf = malloc(str_len + 1);
+	if (buf == NULL)
+		strerr_ret_false("_print_ref_fname_err()");
+	else
+		ft_memcpy(buf, top, str_len);
+	errstr_ret_false(buf, "ambiguous redirect");
+	free(buf);
+	return (false);
+}
+
+// !! ERR_PRINTED
+// -> (root) for validate error
+// -> <inherit> _print_ref_fname_err
+__attribute__((nonnull))
+bool	validate_red_fname(const t_cmdelmarr *elemarr)
+{
+	t_cmd_elem	*elems;
+	size_t		i;
+	size_t		oneelem_len;
+
+	elems = (t_cmd_elem *)(elemarr->p);
+	i = 0;
+	while (i < elemarr->len)
+	{
+		if (!is_cetyp_redirect(elems[i++].type))
+			continue ;
+		oneelem_len = _one_elem_count(elemarr, i);
+		if (!_validate_red_fname(elems, &i, oneelem_len))
+			return (_print_ref_fname_err(elems + i, oneelem_len));
+	}
+	return (true);
+}


### PR DESCRIPTION
redirectで、以下の場合にエラーを吐くようにしました
(いずれについても、DQUOTEで囲った場合は対象外です)

- 値が存在しない変数「のみ」を指定した場合
- ファイル名中に、「値にスペースが含まれる環境変数」が一つでも指定された場合

```sh
tetsu@TRs-MacBook-Pro:~/ftgit/minishell% ./obj/test_build_cmd 'echo abc <<$B$C'  

argv[1]: 'echo abc <<$B$C'
  cmd[0] ~~~~~~~~~~~~~~~~~~
minishell: $B$C: ambiguous redirect
        !!! argv is NULL !!!
tetsu@TRs-MacBook-Pro:~/ftgit/minishell% ./obj/test_build_cmd 'echo abc <<B$C' 

argv[1]: 'echo abc <<B$C'
  cmd[0] ~~~~~~~~~~~~~~~~~~
        [ 0]: `echo`
        [ 1]: `abc`
```
```sh
tetsu@TRs-MacBook-Pro:~/ftgit/minishell% export ABC='abc def'
tetsu@TRs-MacBook-Pro:~/ftgit/minishell% ./obj/test_build_cmd 'echo abc <<"$B"$ABC'

argv[1]: 'echo abc <<"$B"$ABC'
  cmd[0] ~~~~~~~~~~~~~~~~~~
minishell: "$B"$ABC: ambiguous redirect
        !!! argv is NULL !!!
tetsu@TRs-MacBook-Pro:~/ftgit/minishell% ./obj/test_build_cmd 'echo abc <<"$B$ABC"'

argv[1]: 'echo abc <<"$B$ABC"'
  cmd[0] ~~~~~~~~~~~~~~~~~~
        [ 0]: `echo`
        [ 1]: `abc`
```

なお、上記の例いずれについてもheredocでテストしていますが、これはテスターがheredocを処理する前に実行したためです。
実際のminishellではheredoc部分ではエラーを吐かないです。

また、まだargv生成を親プロセス側に移動させていないため、minishell側ではエラーを吐きません。