### PR TITLE
fork前にargv生成を行うようにした

### DIFF
--- a/headers/childs.h
+++ b/headers/childs.h
@@ -29,6 +29,7 @@ typedef struct s_ch_proc_info
 	pid_t		pid;
 	char		**path_arr;
 	char		**envp;
+	char		**argv;
 }	t_ch_proc_info;
 
 typedef t_ch_proc_info	t_cprocinf;

--- a/srcs/childs/_exec_ch_proc_info_arr.c
+++ b/srcs/childs/_exec_ch_proc_info_arr.c
@@ -96,7 +96,8 @@ int	_exec_ch_proc_info_arr(t_cprocinf *cparr, size_t cparr_len)
 		is_signaled = !_exec_until_term(cparr, cparr_len, &i_exec, &cetype);
 		while (i_wait < i_exec)
 		{
-			waitpid(cparr[i_wait++].pid, &cpstat, 0);
+			if (0 < cparr[i_wait++].pid)
+				waitpid(cparr[i_wait - 1].pid, &cpstat, 0);
 			is_signaled = (is_signaled || WIFSIGNALED(cpstat));
 		}
 		if (_is_end_and_get_stat(&cpstat, cetype, is_signaled))

--- a/srcs/childs/childs.c
+++ b/srcs/childs/childs.c
@@ -55,9 +55,10 @@ bool	pipe_fork_exec(t_ch_proc_info *info_arr, size_t index, size_t count)
 
 	if (!create_pipe(info_arr, index))
 		return (false);
-	info_arr[index].pid = fork();
+	if (info_arr[index].argv != NULL)
+		info_arr[index].pid = fork();
 	_errno = errno;
-	if (info_arr[index].pid == PID_FORKED)
+	if (info_arr[index].argv != NULL && info_arr[index].pid == PID_FORKED)
 		exec_command(info_arr, index);
 	if (info_arr[index].fd_from_this != STDOUT_FILENO)
 		close(info_arr[index].fd_from_this);

--- a/srcs/childs/exec_cmd.c
+++ b/srcs/childs/exec_cmd.c
@@ -123,32 +123,27 @@ static noreturn void	_revert_stdio_dispose_arr(
 
 // !! ERR_PRINTED
 // -> <inherit> _proc_redirect
-// -> <inherit> build_cmd
 // -> <inherit> chk_and_get_fpath
 // -> (root) for execve
 __attribute__((nonnull))
 noreturn void	exec_command(t_ch_proc_info *info_arr, size_t index)
 {
 	t_ch_proc_info	info;
-	char			**argv;
 	char			*exec_path;
 	bool			ret;
 
 	info = info_arr[index];
 	if (!_proc_redirect(&info))
-		_revert_stdio_dispose_arr(&info, info_arr, NULL);
+		_revert_stdio_dispose_arr(&info, info_arr, &(info.argv));
 	exec_path = NULL;
-	argv = build_cmd(info.cmd, info.envp);
-	if (argv == NULL)
-		_revert_stdio_dispose_arr(&info, info_arr, NULL);
-	ret = chk_and_get_fpath(argv[0], info.path_arr, &exec_path);
+	ret = chk_and_get_fpath(info.argv[0], info.path_arr, &exec_path);
 	if (ret == true)
 		dup2_and_close(&info);
 	dispose_proc_info_arr(info_arr);
 	if (ret == true)
-		execve(exec_path, argv, info.envp);
+		execve(exec_path, info.argv, info.envp);
 	if (ret == true)
-		strerr_ret_false(argv[0]);
-	_revert_stdio_dispose_arr(&info, NULL, &argv);
+		strerr_ret_false(info.argv[0]);
+	_revert_stdio_dispose_arr(&info, NULL, &(info.argv));
 	exit(1);
 }


### PR DESCRIPTION
fork後にargv生成を行う実装にしていたが、これだとbuiltinの判別ができなくなる。
そこで、fork前にargv生成を行うことにより、実行すべきプログラムの判別が可能になる。

なお、builtinの呼び出し機能自体はここでは実装しない。

また、argv生成に失敗した場合、pipeの接続は行うものの子プロセスの生成は行わない。