### PR TITLE
mainでbuiltinを実行した時の戻り値を修正

### DIFF
--- a/srcs/childs/_exec_ch_proc_info_arr.c
+++ b/srcs/childs/_exec_ch_proc_info_arr.c
@@ -6,7 +6,7 @@
 /*   By: kitsuki <kitsuki@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/22 22:55:33 by kfujita           #+#    #+#             */
-/*   Updated: 2023/06/03 22:44:12 by kitsuki          ###   ########.fr       */
+/*   Updated: 2023/06/04 00:00:17 by kitsuki          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,7 +30,7 @@ static bool	_is_end_and_get_stat(int cpstat, t_cetyp cetype, bool is_signaled,
 {
 	if (cpstat >> 16 != 0)
 	{
-		*exit_status = cpstat;
+		*exit_status = cpstat >> 8;
 		return (true);
 	}
 	if (is_signaled || !WIFEXITED(cpstat))

--- a/srcs/childs/exec_cmd.c
+++ b/srcs/childs/exec_cmd.c
@@ -6,7 +6,7 @@
 /*   By: kitsuki <kitsuki@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/07 19:05:51 by kfujita           #+#    #+#             */
-/*   Updated: 2023/06/03 21:46:18 by kitsuki          ###   ########.fr       */
+/*   Updated: 2023/06/04 00:07:49 by kitsuki          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -134,7 +134,11 @@ noreturn void	exec_command(t_ch_proc_info *info_arr, size_t index, int status)
 		exec_builtin(info.argv, &status);
 	else if (ret == true)
 		execve(exec_path, info.argv, info.envp);
-	if (!is_builtin(info.argv) && ret == true)
-		strerr_ret_false(info.argv[0]);
+	if (!is_builtin(info.argv))
+	{
+		status = 1;
+		if (ret == true)
+			strerr_ret_false(info.argv[0]);
+	}
 	_revert_stdio_dispose_arr(&info, NULL, status);
 }

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -6,7 +6,7 @@
 /*   By: kitsuki <kitsuki@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/03 18:45:07 by kfujita           #+#    #+#             */
-/*   Updated: 2023/06/03 21:29:27 by kitsuki          ###   ########.fr       */
+/*   Updated: 2023/06/03 23:57:29 by kitsuki          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -107,7 +107,7 @@ static int	do_loop(void)
 	int		ret;
 
 	ret = 0;
-	while (ret >> 16 == 0)
+	while (ret >> 8 == 0)
 	{
 		register_rl_ev_hook_handler();
 		line = readline(PROMPT_STR);


### PR DESCRIPTION
mainでbuiltinを実行した後のerrnoが、シグナルのために8ビットシフトしたままの状態で、正常に戻せていなかった為、修正しました。また、execve周りで実行に失敗した際、前回のerrnoをそのまま利用してしまっていたため、1を返すように修正しました。