### PR TITLE
存在しない変数にargvを生成しないようにした

### DIFF
--- a/headers/_build_cmd.h
+++ b/headers/_build_cmd.h
@@ -39,4 +39,10 @@ bool	vect_insert_range(t_vect *vect, size_t index, void *d, size_t len)
 bool	elems_make_flat(t_cmdelmarr *elemarr)
 		__attribute__((nonnull));
 
+bool	_is_value_exists(
+			const t_cmd_elem *elems,
+			size_t len
+			)
+		__attribute__((nonnull));
+
 #endif

--- a/srcs/build_cmd/_get_argc.c
+++ b/srcs/build_cmd/_get_argc.c
@@ -14,6 +14,30 @@
 
 #include "_build_cmd.h"
 
+// !! NO_ERROR
+__attribute__((nonnull))
+bool	_is_value_exists(
+	const t_cmd_elem *elems,
+	size_t len
+)
+{
+	size_t	i;
+
+	if (!is_cetyp_var_or_normal(elems->type))
+		return (false);
+	i = 0;
+	while (i < len)
+	{
+		if (elems[i].type == CMDTYP_NORMAL
+			|| elems[i].type == CMDTYP_QUOTE_VAR)
+			return (true);
+		if (elems[i].p_malloced != NULL)
+			return (true);
+		i += 1;
+	}
+	return (false);
+}
+
 // !! MUST_PRINT_ERROR_IN_CALLER
 // -> argcがINT_MAXを超過した場合、argcの生成に失敗するため、`-1`が返る
 __attribute__((nonnull))
@@ -21,6 +45,7 @@ int	_get_argc(const t_cmdelmarr *elemarr)
 {
 	size_t			argc;
 	size_t			i;
+	size_t			len;
 	t_cmd_elem		*elem;
 
 	elem = (t_cmd_elem *)(elemarr->p);
@@ -28,11 +53,12 @@ int	_get_argc(const t_cmdelmarr *elemarr)
 	argc = 0;
 	while (i < elemarr->len)
 	{
-		if (is_cetyp_var_or_normal(elem[i].type))
-			argc++;
+		len = _one_elem_count(elemarr, i);
+		if (_is_value_exists(elem + i, len))
+			argc += 1;
 		if (INT_MAX <= argc)
 			return (-1);
-		i += _one_elem_count(elemarr, i);
+		i += len;
 	}
 	return (argc);
 }

--- a/srcs/build_cmd/build_cmd.c
+++ b/srcs/build_cmd/build_cmd.c
@@ -92,7 +92,8 @@ char	*_get_argv_one(const t_cmdelmarr *elemarr, size_t *i_start)
 		elem = (t_cmd_elem *)(elemarr->p) + *i_start;
 		current_seg_len = _one_elem_count(elemarr, *i_start);
 		*i_start += current_seg_len;
-		if (!is_cetyp_var_or_normal(elem->type))
+		if (!_is_value_exists(elem, current_seg_len)
+			|| !is_cetyp_var_or_normal(elem->type))
 			continue ;
 		tmp = _gen_argv_one_str(elem, current_seg_len);
 		if (tmp == NULL)

--- a/srcs/childs/env_util.c
+++ b/srcs/childs/env_util.c
@@ -46,6 +46,8 @@ const char	*get_env_value_nlen(char *const envp[], const char *name,
 		p_value = is_this_requested_env(*envp, name, name_len);
 		envp++;
 	}
+	if (p_value != NULL && *p_value == '\0')
+		return (NULL);
 	return (p_value);
 }
 


### PR DESCRIPTION
```sh
$ ./minishell -c './obj/tool_print_argv a "$SPC" $SPC$USE c'
argv[0]: `./obj/tool_print_argv`
argv[1]: `a`
argv[2]: `" "`
argv[3]: `"`
argv[4]: `"`
argv[5]: `c`
```
```sh
bash-3.2$ ./obj/tool_print_argv a "$SPC" $SPC$USE c
argv[0]: `./obj/tool_print_argv`
argv[1]: `a`
argv[2]: `" "`
argv[3]: `"`
argv[4]: `"`
argv[5]: `c`
bash-3.2$ 
```
