### PR TITLE
`heap-use-after-free`を起こさないようにした

### DIFF
--- a/srcs/builtin/_environ_utils.c
+++ b/srcs/builtin/_environ_utils.c
@@ -106,8 +106,8 @@ bool	remove_environ(char *name)
 		src_envs++;
 	}
 	*tmp = NULL;
+	free(*target);
 	free(*get_saved_environs());
 	*get_saved_environs() = envs;
-	free(*target);
 	return (true);
 }


### PR DESCRIPTION
free直後のアクセスだったから大丈夫だったかもしれないけど、念のためfree前に移動させた