### PR TITLE
heredoc失敗時にtmpfileを削除するようにした

### DIFF
--- a/srcs/childs/_parse_exec.c
+++ b/srcs/childs/_parse_exec.c
@@ -33,7 +33,10 @@ int	_parse_exec(const char *str, int exit_stat)
 	if (!_validate_input(&arr, &validate_input_err))
 		return (validate_input_err);
 	if (!chk_do_heredoc(&arr))
+	{
+		rm_tmpfile(&arr);
 		return (dispose_t_cmdarr(&arr) + 1);
+	}
 	cparr = init_ch_proc_info_arr(&arr);
 	if (cparr == NULL)
 		exit_stat = 1;

--- a/srcs/heredoc/create_tmpfile.c
+++ b/srcs/heredoc/create_tmpfile.c
@@ -85,6 +85,16 @@ static bool	_set_next_fname(char *fname_btm)
 	return (true);
 }
 
+static int	_err_chk_proc(int fd, char **fname_save)
+{
+	if (0 <= fd)
+		return (fd);
+	strerr_ret_false(*fname_save);
+	free(*fname_save);
+	*fname_save = NULL;
+	return (-1);
+}
+
 // tmpファイルを作成する。書き込み専用で作成し、基本的に呼び出し元で責任をもって削除する。
 // `fname_save`にはファイルパスが記録される。
 // !! ERR_PRINTED
@@ -111,7 +121,7 @@ int	create_tmpfile(char *const *envp, char **fname_save)
 		}
 		fd = open(*fname_save, O_WRONLY | O_CREAT | O_EXCL, 0600);
 		if (fd < 0 && errno != EEXIST)
-			return ((strerr_ret_false(*fname_save) * 0) - 1);
+			break ;
 	}
-	return (fd);
+	return (_err_chk_proc(fd, fname_save));
 }

--- a/srcs/heredoc/rm_tmpfile.c
+++ b/srcs/heredoc/rm_tmpfile.c
@@ -33,6 +33,8 @@ static int	_rm_tmpfile_from_elems(t_cmd_elem *elemarr, size_t len)
 	{
 		if (elemarr[i++].type != CMDTYP_RED_HEREDOC_SAVED)
 			continue ;
+		if (elemarr[i - 1].p_malloced == NULL)
+			continue ;
 		if (unlink(elemarr[i - 1].p_malloced) != 0)
 			strerr_ret_false(elemarr[i - 1].p_malloced);
 		free((char *)(elemarr[i - 1].p_malloced));


### PR DESCRIPTION
Ctrl-C等でheredocが終了した際、今まではtmpfileが削除されない状態だった。
今回はこれを修正し、heredocがdocが異常終了した場合もtmpfileを削除するようにした。