### PR TITLE
SIGQUITで子プロセスが正常に終了しないバグを修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ SRCS_SERIALIZER	:= \
 
 SRCS_SIGNAL =\
 	init_sig_handler.c\
+	restore_sig_handler.c\
 
 SRCS_VALIDATOR =\
 	_validate_input.c\

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ SRCS_CHILDS	:=\
 SRCS_UTILS :=\
 	err_ret_false.c\
 	free_2darr.c\
+	print_sig.c\
 
 SRCS_HEREDOC :=\
 	chk_do_heredoc.c\

--- a/headers/error_utils.h
+++ b/headers/error_utils.h
@@ -16,9 +16,14 @@
 // - bool
 # include <stdbool.h>
 
+// - pid
+#include <sys/_types/_pid_t.h>
+
 bool	perr_ret_false(const char *str);
 bool	strerr_ret_false(const char *str);
 bool	strerr_errno_ret_false(const char *str, int _errno);
 bool	errstr_ret_false(const char *str1, const char *str2);
+
+bool	print_sig_ret_false(pid_t pid, int sig);
 
 #endif

--- a/headers/error_utils.h
+++ b/headers/error_utils.h
@@ -17,7 +17,7 @@
 # include <stdbool.h>
 
 // - pid
-#include <sys/_types/_pid_t.h>
+# include <sys/_types/_pid_t.h>
 
 bool	perr_ret_false(const char *str);
 bool	strerr_ret_false(const char *str);

--- a/headers/signal_handling.h
+++ b/headers/signal_handling.h
@@ -18,5 +18,6 @@
 bool	get_is_interrupted(void);
 bool	init_sig_handler(void);
 void	register_rl_ev_hook_handler(void);
+bool	restore_sig_handler(void);
 
 #endif

--- a/srcs/childs/_exec_ch_proc_info_arr.c
+++ b/srcs/childs/_exec_ch_proc_info_arr.c
@@ -87,8 +87,7 @@ static t_cetyp	_exec_until_term(t_cprocinf *cparr, size_t cparr_len,
 __attribute__((nonnull))
 static bool	_wait_set_is_signaled(
 	const t_cprocinf *info,
-	int *cpstat,
-	bool *is_signaled
+	int *cpstat
 )
 {
 	if (info->pid <= 0)
@@ -99,7 +98,6 @@ static bool	_wait_set_is_signaled(
 			return (strerr_ret_false("waitpid"));
 	if (WIFEXITED(*cpstat) || !WIFSIGNALED(*cpstat))
 		return (true);
-	*is_signaled = true;
 	return (!print_sig_ret_false(info->pid, WTERMSIG(*cpstat)));
 }
 
@@ -123,7 +121,7 @@ int	_exec_ch_proc_info_arr(t_cprocinf *cparr, size_t cparr_len, int exit_stat)
 		cpstat = exit_stat;
 		is_signaled = !_exec_until_term(cparr, cparr_len, &i_exec, &cpstat);
 		while (i_wait < i_exec)
-			_wait_set_is_signaled(cparr + i_wait++, &cpstat, &is_signaled);
+			_wait_set_is_signaled(cparr + i_wait++, &cpstat);
 		cetype = get_cmdterm(cparr[i_exec - 1].cmd);
 		if (_is_end_and_get_stat(cpstat, cetype, is_signaled, &exit_stat))
 			break ;

--- a/srcs/childs/_exec_ch_proc_info_arr.c
+++ b/srcs/childs/_exec_ch_proc_info_arr.c
@@ -91,8 +91,6 @@ static bool	_wait_set_is_signaled(
 	bool *is_signaled
 )
 {
-	if (*is_signaled)
-		*cpstat = 0;
 	if (info->pid <= 0)
 		return (true);
 	errno = 0;

--- a/srcs/childs/exec_cmd.c
+++ b/srcs/childs/exec_cmd.c
@@ -38,6 +38,7 @@
 #include "_filectrl_tools.h"
 #include "_redirect.h"
 #include "utils.h"
+#include "signal_handling.h"
 
 // !! PRINT_ERROR
 // -> (root) for dup2 function
@@ -132,10 +133,11 @@ noreturn void	exec_command(t_ch_proc_info *info_arr, size_t index, int status)
 	dispose_proc_info_arr(info_arr);
 	if (is_builtin(info.argv))
 		exec_builtin(info.argv, &status);
-	else if (ret == true)
-		execve(exec_path, info.argv, info.envp);
-	if (!is_builtin(info.argv))
+	else
 	{
+		ret = restore_sig_handler();
+		if (ret == true)
+			execve(exec_path, info.argv, info.envp);
 		status = 1;
 		if (ret == true)
 			strerr_ret_false(info.argv[0]);

--- a/srcs/signal_handling/init_sig_handler.c
+++ b/srcs/signal_handling/init_sig_handler.c
@@ -47,7 +47,7 @@ static int	_rl_ev_hook_handler(void)
 {
 	if (!g_is_interrupted)
 		return (0);
-	rl_event_hook = NULL;
+	rl_replace_line("", 0);
 	rl_done = true;
 	return (0);
 }
@@ -82,8 +82,6 @@ bool	init_sig_handler(void)
 
 void	register_rl_ev_hook_handler(void)
 {
-	if (g_is_interrupted)
-		write(STDOUT_FILENO, "\n", 1);
 	g_is_interrupted = false;
 	rl_event_hook = _rl_ev_hook_handler;
 }

--- a/srcs/signal_handling/restore_sig_handler.c
+++ b/srcs/signal_handling/restore_sig_handler.c
@@ -1,0 +1,34 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   restore_sig_handler.c                              :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/06/10 11:11:11 by kfujita           #+#    #+#             */
+/*   Updated: 2023/06/10 11:28:37 by kfujita          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+// - sigaction
+// - sigemptyset
+#include <signal.h>
+
+// - NULL
+#include <stddef.h>
+
+#include "error_utils.h"
+#include "signal_handling.h"
+
+bool	restore_sig_handler(void)
+{
+	struct sigaction	action;
+
+	action.sa_flags = 0;
+	action.sa_handler = SIG_DFL;
+	if (sigaction(SIGQUIT, &action, NULL) != 0)
+		return (strerr_ret_false("restore SIGQUIT handler"));
+	if (sigaction(SIGINT, &action, NULL) != 0)
+		return (strerr_ret_false("restore SIGINT handler"));
+	return (true);
+}

--- a/srcs/utils/print_sig.c
+++ b/srcs/utils/print_sig.c
@@ -1,0 +1,77 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   print_sig.c                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/06/10 11:33:17 by kfujita           #+#    #+#             */
+/*   Updated: 2023/06/10 11:57:29 by kfujita          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+// - SIGQUIT / SIGINT etc.
+#include <signal.h>
+
+#include <unistd.h>
+
+#include "ft_printf/ft_printf.h"
+
+#include "error_utils.h"
+
+static const char	*_get_sig_str(int sig)
+{
+	if (sig == SIGSEGV)
+		return ("SIGSEGV");
+	else if (sig == SIGSYS)
+		return ("SIGSYS");
+	else if (sig == SIGPIPE)
+		return ("SIGPIPE");
+	else if (sig == SIGALRM)
+		return ("SIGALRM");
+	else if (sig == SIGTERM)
+		return ("SIGTERM");
+	else if (sig == SIGURG)
+		return ("SIGURG");
+	else if (sig == SIGSTOP)
+		return ("SIGSTOP");
+	else if (sig == SIGTSTP)
+		return ("STGTSTP");
+	else if (sig == SIGCONT)
+		return ("SIGCONT");
+	else if (sig == SIGCHLD)
+		return ("SIGCHLD");
+	else if (sig == SIGTTIN)
+		return ("SIGTTIN");
+	else if (sig == SIGTTOU)
+		return ("SIGTTOU");
+	return ("!! UNKNOWN SIGNAL !!");
+}
+
+bool	print_sig_ret_false(pid_t pid, int sig)
+{
+	const char	*sigstr;
+
+	if (sig == SIGHUP)
+		sigstr = "SIGHUP";
+	else if (sig == SIGINT)
+		sigstr = "SIGINT";
+	else if (sig == SIGQUIT)
+		sigstr = "SIGQUIT";
+	else if (sig == SIGILL)
+		sigstr = "SIGILL";
+	else if (sig == SIGTRAP)
+		sigstr = "SIGTRAP";
+	else if (sig == SIGABRT)
+		sigstr = "SIGABRT";
+	else if (sig == SIGFPE)
+		sigstr = "SIGFPE";
+	else if (sig == SIGKILL)
+		sigstr = "SIGKILL";
+	else if (sig == SIGBUS)
+		sigstr = "SIGBUS";
+	else
+		sigstr = _get_sig_str(sig);
+	return (ft_dprintf(STDERR_FILENO, "minishell: [%d]: %s (%d)\n",
+			pid, sigstr, sig));
+}


### PR DESCRIPTION
ついでに、どのシグナルで終了したかも表示するようにした

```sh
minishell> cat
^Cminishell: [62543]: SIGINT (2)
```
```sh
minishell> cat
^\minishell: [62545]: SIGQUIT (3)
minishell> echo $?
131
```
```sh
minishell> cat|cat|ls
Doxyfile	a.out		libft		obj
Makefile	headers		minishell	srcs
^Cminishell: [62606]: SIGINT (2)
minishell: [62607]: SIGINT (2)
minishell> echo $?
0
```