### PR TITLE
古いFDをCloseするかの判定でIN/OUTの指定をミスしていたので修正

### DIFF
--- a/srcs/childs/_redirect.c
+++ b/srcs/childs/_redirect.c
@@ -65,7 +65,7 @@ static bool	_open_set_close_fd(t_ch_proc_info *info, t_cmd_elem_type type,
 		info->fd_to_this = fd;
 		return (true);
 	}
-	if (info->fd_from_this != STDIN_FILENO)
+	if (info->fd_from_this != STDOUT_FILENO)
 		close(info->fd_from_this);
 	info->fd_from_this = fd;
 	return (true);


### PR DESCRIPTION
```sh
etsu@TRs-MacBook-Pro:~/ftgit/minishell% ./minishell -c 'ls > tmp/a > tmp/b'           
tetsu@TRs-MacBook-Pro:~/ftgit/minishell% cat tmp/a
tetsu@TRs-MacBook-Pro:~/ftgit/minishell% cat tmp/b
Doxyfile
Makefile
a.o
a.out
headers
libft
minishell
obj
srcs
tmp
tetsu@TRs-MacBook-Pro:~/ftgit/minishell% 
```
```sh
tetsu@TRs-MacBook-Pro:~/ftgit/minishell% ./minishell -c 'ls > tmp/a > tmp/b > tmp/c'
tetsu@TRs-MacBook-Pro:~/ftgit/minishell% 
```
```sh
tetsu@TRs-MacBook-Pro:~/ftgit/minishell% ./minishell -c 'ls > tmp/a > tmp/b > tmp/c > tmp/d'
tetsu@TRs-MacBook-Pro:~/ftgit/minishell% cat tmp/d                                          
Doxyfile
Makefile
a.o
a.out
headers
libft
minishell
obj
srcs
tmp
tetsu@TRs-MacBook-Pro:~/ftgit/minishell% 
```