### PR TITLE
次に渡した宛先パイプ口が子プロセスで閉じていないバグを修正

### DIFF
--- a/srcs/childs/_redirect.c
+++ b/srcs/childs/_redirect.c
@@ -65,7 +65,7 @@ static bool	_open_set_close_fd(t_ch_proc_info *info, t_cmd_elem_type type,
 		info->fd_to_this = fd;
 		return (true);
 	}
-	if (info->fd_from_this != STDIN_FILENO)
+	if (info->fd_from_this != STDOUT_FILENO)
 		close(info->fd_from_this);
 	info->fd_from_this = fd;
 	return (true);

--- a/srcs/childs/childs.c
+++ b/srcs/childs/childs.c
@@ -68,7 +68,7 @@ bool	pipe_fork_exec(t_ch_proc_info *info_arr, size_t index,
 	{
 		if ((index + 1) != count
 			&& info_arr[index + 1].fd_to_this != STDIN_FILENO)
-			close(info_arr[index].fd_to_this);
+			close(info_arr[index + 1].fd_to_this);
 		return (strerr_errno_ret_false("(fork)", _errno));
 	}
 	return (true);

--- a/srcs/childs/childs.c
+++ b/srcs/childs/childs.c
@@ -57,6 +57,9 @@ bool	pipe_fork_exec(t_ch_proc_info *info_arr, size_t index,
 		return (false);
 	if (info_arr[index].argv != NULL)
 		info_arr[index].pid = fork();
+	if (info_arr[index].pid <= 0 && (index + 1) != count
+		&& info_arr[index + 1].fd_to_this != STDIN_FILENO)
+		close(info_arr[index + 1].fd_to_this);
 	_errno = errno;
 	if (info_arr[index].argv != NULL && info_arr[index].pid == PID_FORKED)
 		exec_command(info_arr, index, exit_status);
@@ -65,11 +68,6 @@ bool	pipe_fork_exec(t_ch_proc_info *info_arr, size_t index,
 	if (info_arr[index].fd_to_this != STDIN_FILENO)
 		close(info_arr[index].fd_to_this);
 	if (info_arr[index].pid < 0)
-	{
-		if ((index + 1) != count
-			&& info_arr[index + 1].fd_to_this != STDIN_FILENO)
-			close(info_arr[index + 1].fd_to_this);
 		return (strerr_errno_ret_false("(fork)", _errno));
-	}
 	return (true);
 }


### PR DESCRIPTION
なお、exit statusが130になるバグは #79 により修正される

(#79 merge後)
```sh
tetsu@TRs-MacBook-Pro:~/ftgit/minishell% bash -c 'cat|cat|ls'
Doxyfile	a.o		headers		minishell	srcs
Makefile	a.out		libft		obj		tmp


tetsu@TRs-MacBook-Pro:~/ftgit/minishell% echo $?
0
tetsu@TRs-MacBook-Pro:~/ftgit/minishell% ./minishell -c 'cat|cat|ls'
Doxyfile	a.o		headers		minishell	srcs
Makefile	a.out		libft		obj		tmp


minishell: [93894]: SIGPIPE (13)
minishell: [93895]: SIGPIPE (13)
tetsu@TRs-MacBook-Pro:~/ftgit/minishell% echo $?
0
tetsu@TRs-MacBook-Pro:~/ftgit/minishell% 
```