### PR TITLE
EOFによる終了時に `exit` を表示するようにした

### DIFF
--- a/srcs/main.c
+++ b/srcs/main.c
@@ -114,7 +114,10 @@ static int	do_loop(void)
 		if (get_is_interrupted())
 			ret = 1;
 		else if (line == NULL)
+		{
+			write(STDERR_FILENO, "exit\n", 5);
 			return (ret);
+		}
 		else if (*line != '\0')
 		{
 			add_history(line);
@@ -142,6 +145,7 @@ int	main(int argc, const char *argv[], char **envp)
 		dispose_environs();
 		return (ret);
 	}
+	rl_outstream = stderr;
 	ret = do_loop();
 	dispose_environs();
 	return (ret);


### PR DESCRIPTION
出力が新しい行に表示されてしまうけど、その対応は諦めることにする。

```sh
tetsu@TRs-MacBook-Pro:~/ftgit/minishell% ./minishell     
minishell> 
exit
tetsu@TRs-MacBook-Pro:~/ftgit/minishell% bash

The default interactive shell is now zsh.
To update your account to use zsh, please run `chsh -s /bin/zsh`.
For more details, please visit https://support.apple.com/kb/HT208050.
bash-3.2$ exit
tetsu@TRs-MacBook-Pro:~/ftgit/minishell% 
```