### PR TITLE
コマンドが見つからなかったときにエラーが二重で出るバグを修正

### DIFF
--- a/srcs/childs/exec_cmd.c
+++ b/srcs/childs/exec_cmd.c
@@ -135,7 +135,7 @@ noreturn void	exec_command(t_ch_proc_info *info_arr, size_t index, int status)
 		exec_builtin(info.argv, &status);
 	else
 	{
-		ret = restore_sig_handler();
+		ret = (ret && restore_sig_handler());
 		if (ret == true)
 			execve(exec_path, info.argv, info.envp);
 		status = 1;


### PR DESCRIPTION
`chk_and_get_fpath` でファイルが見つからなかったエラーを出したのに、execveして失敗してしまっていたため。