### PR TITLE
コンパイルエラーを修正

### DIFF
--- a/headers/error_utils.h
+++ b/headers/error_utils.h
@@ -17,7 +17,7 @@
 # include <stdbool.h>
 
 // - pid
-# include <sys/_types/_pid_t.h>
+# include <unistd.h>
 
 bool	perr_ret_false(const char *str);
 bool	strerr_ret_false(const char *str);


### PR DESCRIPTION
codespacesではコンパイルできなかったので変えましたが、校舎Macだと変えなくても実行可能なのでしょうか...？